### PR TITLE
Fix API Docker build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
     ports:
       - '8080:8080'
   api:
-    build: ./packages/apps/api
+    build:
+      context: .
+      dockerfile: packages/apps/api/Dockerfile
     ports:
       - '3000:3000'
     depends_on:

--- a/packages/apps/api/Dockerfile
+++ b/packages/apps/api/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY . .
+COPY packages/apps/api ./packages/apps/api
+COPY packages/utils ./packages/utils
+COPY packages/config ./packages/config
+WORKDIR /app/packages/apps/api
 RUN npm install && npm run build
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- set Docker context to repo root in `docker-compose.yml`
- copy api, utils, and config directories in `Dockerfile` so TypeScript build works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b15417f6c83278fa180fab79f0f1b