### PR TITLE
Add Docker ignore

### DIFF
--- a/packages/apps/api/.dockerignore
+++ b/packages/apps/api/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+test
+dist


### PR DESCRIPTION
## Summary
- avoid copying heavy directories by adding a `.dockerignore` for the API package

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1553f0e88327a960c15244312c42