### PR TITLE
Implement OpenAI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Run mobile:
 cd packages/apps/mobile
 expo start
 ```
+
+### Environment Variables
+
+Set `OPENAI_API_KEY` to enable OpenAI requests from utility functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12868,6 +12868,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.7.0.tgz",
+      "integrity": "sha512-zXWawZl6J/P5Wz57/nKzVT3kJQZvogfuyuNVCdEp4/XU2UNrjL7SsuNpWAyLZbo6HVymwmnfno9toVzBhelygA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ora": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
@@ -16535,6 +16556,7 @@
       "name": "@gympro/utils",
       "version": "1.0.0",
       "dependencies": {
+        "openai": "^5.7.0",
         "zod": "^3.22.2"
       }
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "zod": "^3.22.2"
+    "zod": "^3.22.2",
+    "openai": "^5.7.0"
   }
 }

--- a/packages/utils/src/openai.ts
+++ b/packages/utils/src/openai.ts
@@ -1,8 +1,14 @@
 /**
  * OpenAI client with retry logic.
- * Client stub for offline usage.
  */
+import OpenAI from 'openai';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || '' });
+
 export const createChatCompletion = async (prompt: string): Promise<string> => {
-  // TODO: integrate real OpenAI call
-  return Promise.resolve(`Response for: ${prompt}`);
+  const response = await client.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return response.choices[0]?.message?.content ?? '';
 };

--- a/packages/utils/test/openai.test.ts
+++ b/packages/utils/test/openai.test.ts
@@ -1,0 +1,27 @@
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{ message: { content: 'hello' } }],
+          }),
+        },
+      },
+    })),
+  };
+});
+
+import { createChatCompletion } from '../src/openai';
+import OpenAI from 'openai';
+
+describe('createChatCompletion', () => {
+  it('returns message content from OpenAI', async () => {
+    const result = await createChatCompletion('hi');
+    expect(result).toBe('hello');
+    const instance = (OpenAI as jest.MockedClass<typeof OpenAI>).mock
+      .results[0].value;
+    expect(instance.chat.completions.create).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate real OpenAI client using `openai` package
- add environment variable docs
- add unit tests for `createChatCompletion`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b1569d5e8832791b67a59b739d25a